### PR TITLE
Can be sent a message when Error Response is created

### DIFF
--- a/src/Exception/InvalidResponse.php
+++ b/src/Exception/InvalidResponse.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Dafiti\Silex\Exception;
+
+class InvalidResponse extends \Exception
+{
+    public function __construct()
+    {
+        $message = 'The Returned Value Is Not A Symfony\Component\HttpFoundation\Response Instance Or Child From It';
+        parent::__construct($message);
+    }
+}

--- a/src/Response.php
+++ b/src/Response.php
@@ -15,13 +15,22 @@ class Response
     private $content;
 
     /**
+     * @var string
+     */
+    private $errorMessage;
+
+    /**
      * @param $statusCode
      * @param $content
      */
-    public function __construct($statusCode = 200, $content = null)
+    public function __construct($statusCode = 200, $content = null, $message = null)
     {
         $this->setStatusCode($statusCode);
         $this->setContent($content);
+
+        if (!is_null($message)) {
+            $this->setErrorMessage($message);
+        }
     }
 
     /**
@@ -59,5 +68,25 @@ class Response
     public function getContent()
     {
         return $this->content;
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
+    }
+
+    /**
+     * @param string $errorMessage
+     */
+    public function setErrorMessage($errorMessage)
+    {
+        if (!is_string($errorMessage)) {
+            throw new \InvalidArgumentException('Argument Is Not A String');
+        }
+
+        $this->errorMessage = $errorMessage;
     }
 }

--- a/src/Response/Factory.php
+++ b/src/Response/Factory.php
@@ -4,8 +4,9 @@ namespace Dafiti\Silex\Response;
 
 use Dafiti\Silex\Response\Factory\Factorable;
 use Dafiti\Silex\Response\Factory\Json;
+use Symfony\Component\HttpFoundation;
 
-class Factory extends AbstractFactory implements Factorable
+class Factory implements Factorable
 {
     /**
      * @var Factorable
@@ -49,7 +50,7 @@ class Factory extends AbstractFactory implements Factorable
     /**
      * @param \Dafiti\Silex\Response $controllerResponse
      *
-     * @return Response
+     * @return HttpFoundation\Response
      */
     public function create(\Dafiti\Silex\Response $controllerResponse)
     {

--- a/src/Response/Factory/Json.php
+++ b/src/Response/Factory/Json.php
@@ -14,15 +14,17 @@ class Json extends AbstractFactory implements Factorable
      *
      * @return HttpFoundation\Response
      */
-    public function create(\Dafiti\Silex\Response $controllerResponse)
+    protected function transform(\Dafiti\Silex\Response $controllerResponse)
     {
         $response = new HttpFoundation\JsonResponse();
+        $response->headers->add(
+            ['Content-Type' => self::CONTENT_TYPE]
+        );
         $response->setStatusCode($controllerResponse->getStatusCode());
 
-        if ($this->isError($controllerResponse->getStatusCode())) {
-            $message = $this->errorMessages[$controllerResponse->getStatusCode()];
+        if ($this->hasError()) {
             $content = [
-                'message' => $message,
+                'message' => $controllerResponse->getErrorMessage(),
             ];
 
             $response->setData($content);

--- a/tests/Exception/InvalidResponseTest.php
+++ b/tests/Exception/InvalidResponseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Dafiti\Silex\Exception;
+
+class InvalidResponseTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @covers  \Dafiti\Silex\Exception\InvalidResponse::__construct
+     * @expectedException \Dafiti\Silex\Exception\InvalidResponse
+     * @expectedExceptionMessage The Returned Value Is Not A Symfony\Component\HttpFoundation\Response Instance Or Child From It
+     */
+    public function testShouldReturnExpectedMessage()
+    {
+        throw new InvalidResponse();
+    }
+}

--- a/tests/Response/Factory/JsonTest.php
+++ b/tests/Response/Factory/JsonTest.php
@@ -7,8 +7,9 @@ class JsonTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider errorResponseProvider
+     * @covers \Dafiti\Silex\Response\Factory\Json::transform
      */
-    public function testCreateShouldReturnJsonResponseWithErrorContent(\Dafiti\Silex\Response $controllerResponse, $errorMessage)
+    public function testCreateShouldReturnJsonResponseWithErrorContentAndDefaultMessage(\Dafiti\Silex\Response $controllerResponse, $errorMessage)
     {
         $expectedStatusCode = $controllerResponse->getStatusCode();
         $expectedContent = json_encode(['message' => $errorMessage]);
@@ -27,23 +28,52 @@ class JsonTest extends PHPUnit_Framework_TestCase
     public static function errorResponseProvider()
     {
         return [
-            [new \Dafiti\Silex\Response(HttpFoundation\Response::HTTP_NOT_ACCEPTABLE), 'Accept Type Not Acceptable'],
-            [new \Dafiti\Silex\Response(HttpFoundation\Response::HTTP_NOT_FOUND), 'Resource Not Found'],
+            [new \Dafiti\Silex\Response(HttpFoundation\Response::HTTP_NOT_ACCEPTABLE), 'Not Acceptable'],
+            [new \Dafiti\Silex\Response(HttpFoundation\Response::HTTP_NOT_FOUND), 'Not Found'],
         ];
     }
 
+
+    /**
+     * @dataProvider errorResponseProvider
+     * @covers \Dafiti\Silex\Response\Factory\Json::transform
+     */
+    public function testCreateShouldReturnJsonResponseWithErrorContentAndSettedMessage(\Dafiti\Silex\Response $controllerResponse, $errorMessage)
+    {
+        $controllerResponse = new \Dafiti\Silex\Response(HttpFoundation\Response::HTTP_NOT_ACCEPTABLE, null, 'My Message');
+
+        $expectedStatusCode = $controllerResponse->getStatusCode();
+        $expectedContent = json_encode(['message' => 'My Message']);
+
+        $jsonFactory = new Factory\Json(Factory\Json::CONTENT_TYPE);
+        $result = $jsonFactory->create($controllerResponse);
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $result);
+        $this->assertEquals($expectedStatusCode, $result->getStatusCode());
+        $this->assertEquals($expectedContent, $result->getContent());
+    }
+
+    /**
+     * @covers \Dafiti\Silex\Response\Factory\Json::transform
+     * @covers \Dafiti\Silex\Response\Factory\Json::getContent
+     */
     public function testCreateShouldReturnJsonResponseWithEmptyContentWhenHasNotContent()
     {
         $expectedStatusCode = HttpFoundation\Response::HTTP_OK;
         $controllerResponse = new \Dafiti\Silex\Response();
-        $jsonFactory = new Factory(Factory\Json::CONTENT_TYPE);
+        $jsonFactory = new Factory\Json(Factory\Json::CONTENT_TYPE);
         $result = $jsonFactory->create($controllerResponse);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $result);
         $this->assertEquals($expectedStatusCode, $result->getStatusCode());
         $this->assertequals('[]', $result->getContent());
+        $this->assertTrue($result->headers->contains('Content-Type', Factory\Json::CONTENT_TYPE));
     }
 
+    /**
+     * @covers \Dafiti\Silex\Response\Factory\Json::transform
+     * @covers \Dafiti\Silex\Response\Factory\Json::getContent
+     */
     public function testCreateShouldReturnJsonResponseWithTransformedContentWhenContentIsNotArray()
     {
         $contentMessage = 'CONTENT FROM CONTROLLER';
@@ -51,15 +81,21 @@ class JsonTest extends PHPUnit_Framework_TestCase
         $expectedContent = json_encode([$contentMessage]);
 
         $controllerResponse = new \Dafiti\Silex\Response($expectedStatusCode, $contentMessage);
-        $jsonFactory = new Factory(Factory\Json::CONTENT_TYPE);
+        $jsonFactory = new Factory\Json(Factory\Json::CONTENT_TYPE);
 
         $result = $jsonFactory->create($controllerResponse);
+
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $result);
         $this->assertEquals($expectedStatusCode, $result->getStatusCode());
         $this->assertequals($expectedContent, $result->getContent());
+        $this->assertTrue($result->headers->contains('Content-Type', Factory\Json::CONTENT_TYPE));
     }
 
+    /**
+     * @covers \Dafiti\Silex\Response\Factory\Json::transform
+     * @covers \Dafiti\Silex\Response\Factory\Json::getContent
+     */
     public function testCreateShouldReturnJsonResponseWithContentWhenContentIsArray()
     {
         $content = ['content' => 'CONTENT FROM CONTROLLER'];
@@ -67,12 +103,13 @@ class JsonTest extends PHPUnit_Framework_TestCase
         $expectedContent = json_encode($content);
 
         $controllerResponse = new \Dafiti\Silex\Response($expectedStatusCode, $content);
-        $jsonFactory = new Factory(Factory\Json::CONTENT_TYPE);
+        $jsonFactory = new Factory\Json(Factory\Json::CONTENT_TYPE);
 
         $result = $jsonFactory->create($controllerResponse);
 
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $result);
         $this->assertEquals($expectedStatusCode, $result->getStatusCode());
         $this->assertequals($expectedContent, $result->getContent());
+        $this->assertTrue($result->headers->contains('Content-Type', Factory\Json::CONTENT_TYPE));
     }
 }


### PR DESCRIPTION
In your Controller, you can do this...

$response = new Response();
$response->setStatusCode(HttpFoundation\Response::HTTP_NOT_FOUND);
$response->setErrorMessage('My Message');

And will receive this response:

HTTP Status Code: 404
{
    "message": "My Message"
}


Before that implementation was impossible to send a message when Response Error was created. Always the default message was sent in Response.